### PR TITLE
Update README and ARCHITECTURE docs for commands, settings and DB models

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,11 @@ RecognizePort = 3737
 - `/search <关键词>` - 搜索音乐
 - `/lyric <URL>` - 获取歌词
 - `/recognize` - 识别语音中的歌曲 (回复语音消息)
+- `/settings` - 设置默认平台和音质
 - `/status` - 查看 Bot 状态和支持的平台
 - `/about` - 关于本 Bot
+- `/rmcache <platform> <trackID>|<URL>|all` - 清理缓存（管理员）
+- `/reload` - 重新加载动态脚本插件（管理员）
 
 ### 支持的 URL 格式
 


### PR DESCRIPTION
### Motivation

- Align project documentation with the current codebase: document available bot commands and admin operations and reflect recent runtime/DB/telegram-driver changes.
- Make architecture notes accurate about repository implementation, data models and group/user settings behavior.

### Description

- Updated `README.md` to document additional commands: `/settings`, admin-only `/rmcache <platform> <trackID>|<URL>|all`, and admin-only `/reload`.
- Updated `ARCHITECTURE.md` to clarify that `SongRepository` is implemented by `bot/db/Repository`, added repository methods (`Last`, `GetGroupSettings`, `UpdateGroupSettings`) to the interface listing, and corrected the Telegram SDK to `github.com/mymmrac/telego`.
- Adjusted the documented data models and schema names to match the code: replaced `SongModel` with `SongInfoModel`, added `GroupSettingsModel` and `BotStatModel`, and added a `group_settings` CREATE TABLE example; changed documented default quality from `high` to `hires` and noted group-level settings priority.
- Minor formatting/structure fixes in `ARCHITECTURE.md` (scripts directory indentation and SQL block placement).

### Testing

- No automated tests were run because these are documentation-only changes and do not modify runtime code or tests, changes validated by inspecting the corresponding source files and interfaces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69823c74b41c8323b423917adc6fb7aa)